### PR TITLE
service: Add option to modify listen address

### DIFF
--- a/config.ini.default
+++ b/config.ini.default
@@ -1,5 +1,6 @@
 [SERVICE]
 endpoint=http://127.0.0.1
+LISTEN_ADDRESS=127.0.0.1
 port=8125
 
 [RESOLVER]

--- a/semantic_id_resolver/service.py
+++ b/semantic_id_resolver/service.py
@@ -97,4 +97,4 @@ if __name__ == '__main__':
     APP.include_router(
         SEMANTIC_ID_RESOLVING_SERVICE.router
     )
-    uvicorn.run(APP, host="127.0.0.1", port=int(config["SERVICE"]["PORT"]))
+    uvicorn.run(APP, host=config["SERVICE"]["LISTEN_ADDRESS"], port=int(config["SERVICE"]["PORT"]))


### PR DESCRIPTION
Previously, uvicorn only listened on 127.0.0.1. This creates problems, when running the service in docker.

We add a configuration option to modify the listen address via the `config.ini`